### PR TITLE
Mark `display_name` as possibly being `null`

### DIFF
--- a/docs/_extra/api-reference/schemas/annotation.yaml
+++ b/docs/_extra/api-reference/schemas/annotation.yaml
@@ -84,6 +84,8 @@ Annotation:
       type: object
       properties:
         display_name:
-          type: string
-          description: The annotation creator's display name
-          example: "Felicity Nunsun"
+          oneOf:
+            - type: string
+              description: The annotation creator's display name
+              example: "Felicity Nunsun"
+            - type: null


### PR DESCRIPTION
I noticed I was getting `null` for the `display_name` prop in my API responses in some cases so I looked into it a bit and found evidence suggesting that this is to be expected [here](https://github.com/hypothesis/client/blob/main/src/types/api.ts#L144) [and](https://github.com/hypothesis/h/blob/main/tests/h/session_test.py#L266) [there](https://github.com/hypothesis/h/blob/main/h/schemas/forms/accounts/edit_profile.py#L30), so I thought I would make a PR to make this more obvious in the docs.